### PR TITLE
Fix pipeline schema import + CFN deploy permissions

### DIFF
--- a/sagemaker-automated-drift-and-trend-monitoring/cloudformation/delete-main-stack.sh
+++ b/sagemaker-automated-drift-and-trend-monitoring/cloudformation/delete-main-stack.sh
@@ -572,6 +572,7 @@ fi
 
 LAST_STATUS=""
 AUTO_RETRIED_EFS=false   # one-shot guard so we don't loop infinitely
+ADAPTIVE_SWEEP_DONE=false # one-shot guard for the mid-flight sweep below
 while true; do
     STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
         --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "DELETE_COMPLETE")
@@ -579,6 +580,37 @@ while true; do
         echo "  ✓ Stack deleted"
         break
     fi
+
+    # ────────────────────────────────────────────────────────────────────
+    # Adaptive mid-flight sweep. SageMaker's async domain tear-down can
+    # recreate NFS security groups and EFS mount targets AFTER the pre-
+    # delete sweep ran but BEFORE CFN reaches the VPC delete. Waiting for
+    # CFN's dependency timeout (typically 30-40 min) is wasteful — as soon
+    # as the SageMakerDomain resource is DELETE_COMPLETE and the VPC is
+    # still DELETE_IN_PROGRESS, we know the async cleanup window is open.
+    # Sweep now so CFN's next VPC-delete attempt succeeds.
+    # ────────────────────────────────────────────────────────────────────
+    if [ "$STATUS" = "DELETE_IN_PROGRESS" ] && ! $ADAPTIVE_SWEEP_DONE; then
+        DOMAIN_GONE=$(aws cloudformation describe-stack-events --stack-name "$STACK_NAME" --region "$REGION" \
+            --query "StackEvents[?LogicalResourceId=='SageMakerDomain' && ResourceStatus=='DELETE_COMPLETE'] | length(@)" \
+            --output text 2>/dev/null || echo "0")
+        VPC_STUCK=$(aws cloudformation describe-stack-events --stack-name "$STACK_NAME" --region "$REGION" \
+            --query "StackEvents[?LogicalResourceId=='VPC' && ResourceStatus=='DELETE_IN_PROGRESS'] | length(@)" \
+            --output text 2>/dev/null || echo "0")
+        if [ "$DOMAIN_GONE" != "0" ] && [ "$VPC_STUCK" != "0" ]; then
+            echo ""
+            echo "  ⚡ Adaptive sweep: SageMakerDomain deleted, VPC delete pending."
+            echo "    Sweeping async-created orphans now (skips CFN's ~30-40 min"
+            echo "    dependency timeout so the next VPC-delete attempt succeeds)..."
+            sweep_all_orphans "adaptive mid-flight (Domain gone, VPC pending)"
+            ADAPTIVE_SWEEP_DONE=true
+            echo "  Continuing to poll for DELETE_COMPLETE..."
+            LAST_STATUS=""
+            sleep 20
+            continue
+        fi
+    fi
+
     if [ "$STATUS" = "DELETE_FAILED" ]; then
         # Check whether the failure is the known "has dependencies" pattern
         # on a subnet (EFS mount target orphan) or VPC (SageMaker SG orphan).

--- a/sagemaker-automated-drift-and-trend-monitoring/cloudformation/sagemaker-mlflow-setup.yaml
+++ b/sagemaker-automated-drift-and-trend-monitoring/cloudformation/sagemaker-mlflow-setup.yaml
@@ -1047,7 +1047,35 @@ Resources:
                   - 'iam:ListRolePolicies'
                   - 'iam:UpdateAssumeRolePolicy'
                 Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ProjectName}-SageMakerExecutionRole'
-        # Lake Formation: the setup script grants DB/table permissions to this
+        # CloudFormation stack deployment: notebook 3 (drift-monitoring) and
+        # notebook 4 (governance/QuickSight) use `aws cloudformation deploy`
+        # from the SageMaker Studio kernel to deploy dependent stacks. The
+        # role already has permissions for the resources inside those stacks
+        # (Lambda, SQS, SNS, CloudWatch, IAM under fraud-*); this grants the
+        # meta-level stack-management actions so CreateChangeSet /
+        # ExecuteChangeSet can succeed.
+        - PolicyName: !Sub '${ProjectName}-CloudFormationStackDeployment'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'cloudformation:CreateChangeSet'
+                  - 'cloudformation:DescribeChangeSet'
+                  - 'cloudformation:ExecuteChangeSet'
+                  - 'cloudformation:DeleteChangeSet'
+                  - 'cloudformation:CreateStack'
+                  - 'cloudformation:UpdateStack'
+                  - 'cloudformation:DeleteStack'
+                  - 'cloudformation:DescribeStacks'
+                  - 'cloudformation:DescribeStackEvents'
+                  - 'cloudformation:DescribeStackResource'
+                  - 'cloudformation:DescribeStackResources'
+                  - 'cloudformation:ListStackResources'
+                  - 'cloudformation:GetTemplate'
+                  - 'cloudformation:GetTemplateSummary'
+                  - 'cloudformation:ValidateTemplate'
+                Resource: '*'
         # role at runtime (lf_client.grant_permissions). Allow the LF grant/
         # admin actions so that self-grant succeeds in any account.
         - PolicyName: !Sub '${ProjectName}-LakeFormationAccess'

--- a/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline.py
+++ b/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline.py
@@ -449,7 +449,14 @@ class FraudDetectionPipeline:
         shutil.copy(pipeline_steps_dir / "seed_athena_tables.py", staging_dir)
         self._stage_schema_sibling(staging_dir)
 
-        logger.info("Staged seed-step source dir: %s (seed_athena_tables.py + schema.py + dataset_schema.yaml)",
+        # Write a requirements.txt so FrameworkProcessor's install_requirements.py
+        # installs pyyaml before running seed_athena_tables.py. schema.py imports
+        # yaml at module load; the base Processing Job image doesn't ship pyyaml,
+        # so without this the step crashes on `import yaml` with
+        # ModuleNotFoundError.
+        (staging_dir / "requirements.txt").write_text("pyyaml\n")
+
+        logger.info("Staged seed-step source dir: %s (seed_athena_tables.py + schema.py + dataset_schema.yaml + requirements.txt)",
                    staging_dir)
         return staging_dir
 

--- a/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline_steps/preprocessing_pyspark.py
+++ b/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline_steps/preprocessing_pyspark.py
@@ -28,11 +28,15 @@ from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql import functions as F
 from pyspark.sql.types import *
 
-# Bundled sibling — pipeline.py's source_dir bundling stages schema.py +
-# dataset_schema.yaml alongside this script (see pipeline.py's
-# _stage_schema_sibling() helper).
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import schema
+# Note: this script previously imported a local `schema` sibling module for
+# reading dataset_schema.yaml. That import fought with the PyPI `schema`
+# validation package pre-installed in the PySpark container image, and
+# SageMaker SDK v3's PySparkProcessor.submit_py_files path has a pydantic
+# bug that prevents shipping the local module cleanly. Since the pipeline
+# always passes --target-column explicitly (see pipeline.py:513), the
+# module isn't actually needed here — the target column default below is
+# a hardcoded fallback for standalone / debug runs only, mirroring the
+# `target_column` value in src/config/dataset_schema.yaml.
 
 # Setup logging
 logging.basicConfig(
@@ -591,9 +595,16 @@ def main():
     parser.add_argument('--limit', type=int, default=None,
                        help='Row limit for testing (applied to BOTH tables)')
 
-    # Target column
-    parser.add_argument('--target-column', type=str, default=schema.target_column(),
-                       help='Target column name')
+    # Target column. Always passed by the pipeline via --target-column
+    # (see pipeline.py:513). The value is sourced from dataset_schema.yaml
+    # on the notebook host (pipeline.py:247's `default_value=
+    # schema.target_column()`) and baked into the pipeline parameter, so
+    # by the time this container runs, the value is already resolved.
+    # required=True: fail loudly if a standalone / debug run forgets to
+    # pass it, rather than silently drifting from the schema YAML.
+    parser.add_argument('--target-column', type=str, required=True,
+                       help='Target column name (required — value comes from '
+                            'dataset_schema.yaml via the pipeline parameter)')
 
     # Output paths (SageMaker ProcessingStep provides these)
     parser.add_argument('--train-output-dir', type=str,

--- a/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline_steps/train.py
+++ b/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline_steps/train.py
@@ -29,7 +29,14 @@ from sklearn.metrics import (
 # dataset_schema.yaml alongside this script (see pipeline.py's
 # _stage_schema_sibling() helper).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import schema
+# Note: this script previously imported a local `schema` sibling module for
+# reading dataset_schema.yaml. That import failed in the XGBoost training
+# container (no schema module shipped). Since the pipeline always passes
+# --target-column and --target-type explicitly (see pipeline.py — the values
+# come from schema.target_column() / schema.target_type() evaluated on the
+# notebook host and threaded through pipeline parameters), the module isn't
+# needed here. Argparse args are `required=True` so standalone/debug runs
+# fail loudly if they forget to pass the values.
 
 # Visualization libraries - try to install if not available
 VISUALIZATION_AVAILABLE = False
@@ -884,12 +891,13 @@ def main():
                        help='Directory containing training data')
     parser.add_argument('--validation-data-dir', type=str, default='/opt/ml/input/data/validation',
                        help='Directory containing validation data')
-    parser.add_argument('--target-column', type=str, default=schema.target_column(),
-                       help='Target column name')
-    parser.add_argument('--target-type', type=str, default=schema.target_type(),
+    parser.add_argument('--target-column', type=str, required=True,
+                       help='Target column name (required — passed by the pipeline '
+                            'from schema.target_column() evaluated on the notebook host)')
+    parser.add_argument('--target-type', type=str, required=True,
                        help='Target column type (boolean/integer/double/string) used to '
-                            'auto-derive XGBoost objective; passed by pipeline.py from '
-                            'schema.target_type()')
+                            'auto-derive XGBoost objective; required — passed by '
+                            'pipeline.py from schema.target_type()')
     parser.add_argument('--xgboost-objective', type=str, default='',
                        help='Explicit XGBoost objective override (e.g. reg:squarederror, '
                             'multi:softprob). Empty string → auto-derive from --target-type.')


### PR DESCRIPTION
  - preprocessing_pyspark.py, train.py: drop  at container scope; the PyPI  package shadows the local module in the processing/training containers. Pipeline already passes required args explicitly; make them argparse required=True.
  - pipeline.py: ship pyyaml via requirements.txt for the seed step so FrameworkProcessor installs it before running seed_athena_tables.py.
  - sagemaker-mlflow-setup.yaml: add CloudFormationStackDeployment inline policy to SageMakerExecutionRole so notebook 3's drift-monitoring stack deploy can create/execute change sets.
