### PR TITLE
Upgrade sklearn & XGBoost containers; fix IAM tag perms & stale stack names

### DIFF
--- a/sagemaker-automated-drift-and-trend-monitoring/cloudformation/cleanup-main-resources.sh
+++ b/sagemaker-automated-drift-and-trend-monitoring/cloudformation/cleanup-main-resources.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
-STACK_NAME="${1:-fraud-detection-sagemaker-setup}"
-REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+# Resolve stack name + region from config (matches deploy-main-stack.sh) so the
+# defaults target the real base stack (PROJECT_NAME) instead of a stale name.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$SCRIPT_DIR/../scripts/_read_config.sh" ] && source "$SCRIPT_DIR/../scripts/_read_config.sh"
+STACK_NAME="${1:-$(get_config PROJECT_NAME 2>/dev/null || echo 'fraud-detection-monitoring')}"
+REGION="${AWS_DEFAULT_REGION:-$(get_config AWS_DEFAULT_REGION 2>/dev/null || echo 'us-east-1')}"
 
 echo "=== SageMaker CloudFormation Stack Cleanup ==="
 echo "Stack: $STACK_NAME"

--- a/sagemaker-automated-drift-and-trend-monitoring/cloudformation/deploy-drift-monitoring.sh
+++ b/sagemaker-automated-drift-and-trend-monitoring/cloudformation/deploy-drift-monitoring.sh
@@ -118,8 +118,15 @@ echo ""
 # --- Pre-flight checks ---
 echo "[Pre-flight checks]"
 
-# Check if main stack exists
-BASE_STACK="fraud-detection-sagemaker-setup"
+# Check if the base stack exists. deploy-main-stack.sh names the base stack
+# after PROJECT_NAME from config (e.g. "fraud-detection-monitoring"), so derive
+# the same value here instead of hardcoding a stale name. Ensure get_config is
+# available (the region block above only sources it when --region was omitted).
+if ! command -v get_config >/dev/null 2>&1; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  [ -f "$SCRIPT_DIR/../scripts/_read_config.sh" ] && source "$SCRIPT_DIR/../scripts/_read_config.sh"
+fi
+BASE_STACK="$(get_config PROJECT_NAME 2>/dev/null || echo 'fraud-detection-monitoring')"
 if ! aws cloudformation describe-stacks \
     --stack-name "$BASE_STACK" \
     --region "$REGION" &>/dev/null; then

--- a/sagemaker-automated-drift-and-trend-monitoring/cloudformation/sagemaker-mlflow-setup.yaml
+++ b/sagemaker-automated-drift-and-trend-monitoring/cloudformation/sagemaker-mlflow-setup.yaml
@@ -941,6 +941,9 @@ Resources:
                   - 'lambda:RemovePermission'
                   - 'lambda:GetFunctionConfiguration'
                   - 'lambda:GetPolicy'
+                  - 'lambda:TagResource'
+                  - 'lambda:UntagResource'
+                  - 'lambda:ListTags'
                 Resource: '*'
         - PolicyName: !Sub '${ProjectName}-SQSAccess'
           PolicyDocument:
@@ -958,6 +961,9 @@ Resources:
                   - 'sqs:DeleteMessage'
                   - 'sqs:PurgeQueue'
                   - 'sqs:ListQueues'
+                  - 'sqs:TagQueue'
+                  - 'sqs:UntagQueue'
+                  - 'sqs:ListQueueTags'
                 Resource: '*'
         - PolicyName: !Sub '${ProjectName}-CloudWatchMetricsAccess'
           PolicyDocument:
@@ -1005,6 +1011,9 @@ Resources:
                   - 'sns:SetTopicAttributes'
                   - 'sns:ListTopics'
                   - 'sns:ListSubscriptionsByTopic'
+                  - 'sns:TagResource'
+                  - 'sns:UntagResource'
+                  - 'sns:ListTagsForResource'
                 Resource: '*'
         # IAM role management for the drift-monitor / monitoring-writer
         # Lambda roles. The notebook (cell-33) and deploy_monitoring_writer

--- a/sagemaker-automated-drift-and-trend-monitoring/src/setup/create_or_update_sagemaker_role.py
+++ b/sagemaker-automated-drift-and-trend-monitoring/src/setup/create_or_update_sagemaker_role.py
@@ -137,7 +137,10 @@ def get_custom_policy(account_id: str, region: str) -> dict:
                     "lambda:DeleteEventSourceMapping",
                     "lambda:GetEventSourceMapping",
                     "lambda:ListEventSourceMappings",
-                    "lambda:UpdateEventSourceMapping"
+                    "lambda:UpdateEventSourceMapping",
+                    "lambda:TagResource",
+                    "lambda:UntagResource",
+                    "lambda:ListTags"
                 ],
                 "Resource": "*"
             },
@@ -154,7 +157,10 @@ def get_custom_policy(account_id: str, region: str) -> dict:
                     "sqs:ReceiveMessage",
                     "sqs:DeleteMessage",
                     "sqs:PurgeQueue",
-                    "sqs:ListQueues"
+                    "sqs:ListQueues",
+                    "sqs:TagQueue",
+                    "sqs:UntagQueue",
+                    "sqs:ListQueueTags"
                 ],
                 "Resource": "*"
             },

--- a/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline.py
+++ b/sagemaker-automated-drift-and-trend-monitoring/src/train_pipeline/pipeline.py
@@ -200,9 +200,9 @@ class FraudDetectionPipeline:
             'processing_instance_type': kwargs.get('processing_instance_type', 'ml.m5.xlarge'),
             'training_instance_type': kwargs.get('training_instance_type', 'ml.m5.xlarge'),
             'transform_instance_type': kwargs.get('transform_instance_type', 'ml.m5.xlarge'),
-            'framework_version': kwargs.get('framework_version', '1.2-1'),
+            'framework_version': kwargs.get('framework_version', '1.4-2'),
             'py_version': kwargs.get('py_version', 'py3'),
-            'xgboost_version': kwargs.get('xgboost_version', '1.7-1'),
+            'xgboost_version': kwargs.get('xgboost_version', '3.0-5'),
         }
 
         # Lambda configuration
@@ -360,13 +360,34 @@ class FraudDetectionPipeline:
         """
         logger.info("Creating Athena seed step...")
 
-        # Use the SKLearn container image — it's small, has boto3, and starts
-        # quickly. We don't import sklearn; we only need a Python runtime.
-        sklearn_image = retrieve_image_uri(
+        # The seed step only needs a generic Python runtime + boto3 (it does
+        # NOT import sklearn). We pin the SageMaker scikit-learn image built on
+        # Python 3.12 (ECR tag `<framework_version>-py312`) instead of the old
+        # 1.2-1 image (Python 3.8). The version comes from config
+        # (`framework_version`, default 1.4-2) — the ONLY sklearn version knob.
+        #
+        # The SDK's image_uris config has no version key that maps to the
+        # py312 tag — retrieve() only ever emits `<version>-cpu-py3` (Python
+        # 3.10 for 1.4-2) and rejects py_version="py312". So we let retrieve()
+        # resolve the region-correct registry account + repository, then swap
+        # the tag to `<version>-py312`. This keeps the account/region portable
+        # (the account differs per region) without hardcoding it. Verified the
+        # 1.4-2-py312 image is present with an identical digest across all
+        # commercial regions checked (us/eu/ap/ca/sa).
+        #
+        # NOTE: the configured framework_version must have a published
+        # `-py312` container build. Today only 1.4-2 does; if you change
+        # framework_version, confirm the `<version>-py312` tag exists in ECR.
+        _sklearn_version = self.config['framework_version']
+        _sklearn_base_uri = retrieve_image_uri(
             framework="sklearn",
             region=self.region,
-            version="1.2-1",
+            version=_sklearn_version,
+            image_scope="training",
         )
+        # e.g. <acct>.dkr.ecr.<region>.amazonaws.com/sagemaker-scikit-learn:1.4-2-cpu-py3
+        #   -> <acct>.dkr.ecr.<region>.amazonaws.com/sagemaker-scikit-learn:1.4-2-py312
+        sklearn_image = f"{_sklearn_base_uri.rsplit(':', 1)[0]}:{_sklearn_version}-py312"
 
         # Bundle seed_athena_tables.py together with schema.py + its YAML
         # sidecar in a source_dir so the container-side `import schema`


### PR DESCRIPTION
  What
  
  - XGBoost 1.7-1 → 3.0-5 (via xgboost_version config — training, evaluation, and serving containers move together).
  - sklearn seed-step image 1.2-1 (Py3.8) → 1.4-2-py312 (Py3.12) — now driven by framework_version config (default
  1.2-1 → 1.4-2), resolved region-portably (tag-swapped since the SDK can't emit the py312 tag).
  - Execution-role IAM: added missing tag actions — lambda:TagResource/UntagResource/ListTags,
  sqs:TagQueue/UntagQueue/ListQueueTags, sns:TagResource/UntagResource/ListTagsForResource (in both the CFN template
  and create_or_update_sagemaker_role.py).
  - Scripts: deploy-drift-monitoring.sh and cleanup-main-resources.sh now derive the base stack name from config
  instead of the stale hardcoded fraud-detection-sagemaker-setup.
  
  Why
  
  Upgrade to current Python/framework runtimes; unblock 3_inference_monitoring.ipynb (SQS tagging) and the
  drift-monitoring stack (lambda:TagResource rollback); fix false "base stack not found" warning.