### PR TITLE
Fix feature_drift_detail view for nested per-feature JSON schema

### DIFF
--- a/sagemaker-automated-drift-and-trend-monitoring/src/governance/create_governance_dashboard.py
+++ b/sagemaker-automated-drift-and-trend-monitoring/src/governance/create_governance_dashboard.py
@@ -1087,18 +1087,36 @@ SELECT
     drifted_columns_share,
     baseline_roc_auc,
     current_roc_auc,
-    feature_name,                    -- Unpacked from JSON
-    drift_score,                     -- Unpacked from JSON
+    feature_name,
+    COALESCE(
+        TRY(CAST(json_format(feature_value) AS DOUBLE)),
+        TRY(CAST(json_extract_scalar(json_format(feature_value), '$.score') AS DOUBLE))
+    ) as drift_score,
+    COALESCE(
+        TRY(CAST(json_extract_scalar(json_format(feature_value), '$.magnitude') AS DOUBLE)),
+        TRY(CAST(json_format(feature_value) AS DOUBLE))
+    ) as drift_magnitude,
+    TRY(json_extract_scalar(json_format(feature_value), '$.method')) as drift_method,
+    TRY(CAST(json_extract_scalar(json_format(feature_value), '$.threshold') AS DOUBLE)) as drift_threshold,
     CASE
-        WHEN drift_score > 0.25 THEN 'Significant'
-        WHEN drift_score > 0.1 THEN 'Moderate'
+        WHEN COALESCE(
+            TRY(CAST(json_extract_scalar(json_format(feature_value), '$.magnitude') AS DOUBLE)),
+            TRY(CAST(json_format(feature_value) AS DOUBLE))
+        ) > 2.5 THEN 'Significant'
+        WHEN COALESCE(
+            TRY(CAST(json_extract_scalar(json_format(feature_value), '$.magnitude') AS DOUBLE)),
+            TRY(CAST(json_format(feature_value) AS DOUBLE))
+        ) > 1.0 THEN 'Moderate'
         ELSE 'Low'
-    END as drift_severity,           -- Computed severity
-    CASE WHEN drift_score > 0.1 THEN true ELSE false END as drift_detected
+    END as drift_severity,
+    CASE WHEN COALESCE(
+        TRY(CAST(json_extract_scalar(json_format(feature_value), '$.magnitude') AS DOUBLE)),
+        TRY(CAST(json_format(feature_value) AS DOUBLE))
+    ) > 1.0 THEN true ELSE false END as drift_detected
 FROM {resolved_database}.monitoring_responses
 CROSS JOIN UNNEST(
-    CAST(json_parse(per_feature_drift_scores) AS MAP(VARCHAR, DOUBLE))
-) AS t(feature_name, drift_score)
+    CAST(json_parse(per_feature_drift_scores) AS MAP(VARCHAR, JSON))
+) AS t(feature_name, feature_value)
 WHERE per_feature_drift_scores IS NOT NULL
     AND per_feature_drift_scores != 'null'
     AND per_feature_drift_scores != '{{}}'
@@ -1978,6 +1996,17 @@ def build_feature_drift_visuals() -> List[Dict[str, Any]]:
     """
     def flcol(name):
         return {'DataSetIdentifier': DS_IDENT_FEATURE_LEVEL, 'ColumnName': name}
+
+    # Reference line at magnitude = 1.0 (drifted threshold: magnitude >= 1.0 means drifted)
+    magnitude_ref_line_1 = [{
+        'Status': 'ENABLED',
+        'DataConfiguration': {'StaticConfiguration': {'Value': 1.0}, 'AxisBinding': 'PRIMARY_YAXIS'},
+        'StyleConfiguration': {'Pattern': 'DASHED', 'Color': '#C00000'},
+        'LabelConfiguration': {
+            'CustomLabelConfiguration': {'CustomLabel': 'magnitude = 1.0 (above = drifted)'},
+            'FontConfiguration': {'FontSize': {'Relative': 'SMALL'}},
+        },
+    }]
 
     f1_score_timeline = {
         'LineChartVisual': {


### PR DESCRIPTION
The notebook writes per_feature_drift_scores as nested JSON ({feature: {score, magnitude, method, threshold}}); rewrite the Athena view to CAST as MAP(VARCHAR, JSON) and unpack via TRY/COALESCE (stays backward-compatible with Lambda's flat schema). Also define the missing magnitude_ref_line_1 variable referenced by build_feature_drift_visuals. SQL from workshop commit 4ccd07a.
